### PR TITLE
Fix for hostnames starting with digits

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -88,6 +88,7 @@ func TestResourceNameSanitation(t *testing.T) {
 		{"åäö.bar.com", "xn---bar-com-zzaj2q"},
 		{"#issue-2.github.com", "_issue-2-github-com"},
 		{"//issue-2.github.com", "__issue-2-github-com"},
+		{"12-issue-12.github.com", "_12-issue-12-github-com"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Fixes #12.
Hostnames that started with characters that are not valid as the start of Terraform identifiers (ie, not ASCII letters or underscore) need to have the identifier prepended with an underscore.